### PR TITLE
Downgraded rstudio to 2026.01.02+418

### DIFF
--- a/rstudio/proxy/Dockerfile
+++ b/rstudio/proxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.31.1-alpine
 
-LABEL maintainer="Sigma2 As <system@sigma2.no>"
+LABEL maintainer="contact@sigma2.no"
 # Add TINI
 RUN apk add --no-cache tini=0.19.0-r3
 

--- a/rstudio/server/Dockerfile
+++ b/rstudio/server/Dockerfile
@@ -5,7 +5,7 @@ FROM rocker/r-ver:4.6.0
 LABEL maintainer="contact@sigma2.no"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2026.04.0+526
+ENV RSTUDIO_VERSION=2026.01.2+418
 ENV PANDOC_VERSION=default
 
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
@@ -22,7 +22,7 @@ ENV TZ="Europe/Oslo" \
     APP_UID=977 \
     APP_GID=977 \
     PKG_R_VERSION=4.6.0 \
-    PKG_RSTUDIO_VERSION=2026.04.0+526 \
+    PKG_RSTUDIO_VERSION=2026.01.2+418 \
     PKG_SHINY_VERSION=1.5.23.1030
 
 # Setup Tini, as S6 does not work when run as non-root users


### PR DESCRIPTION
to resolve issue with database.conf being unreadable we downgrade to an earlier version of rstudio where this issue is not present.